### PR TITLE
Added coffeescript support (pegcs)

### DIFF
--- a/ftdetect/pegjs.vim
+++ b/ftdetect/pegjs.vim
@@ -1,3 +1,4 @@
 " Jade
 autocmd BufNewFile,BufReadPost *.pegjs set filetype=pegjs
+autocmd BufNewFile,BufReadPost *.pegcs set filetype=pegcs
 autocmd BufNewFile,BufReadPost *.language set filetype=pegjs

--- a/syntax/pegcs.vim
+++ b/syntax/pegcs.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language: PEG JS Grammars
+" Language: PEG JS Grammars for CoffeeScript
 " Maintainer: Andrew Lunny <alunny@gmail.com>
 " Latest Revision: 15 June 2012
 " License: MIT
@@ -11,5 +11,5 @@ endif
 runtime! syntax/pegjs-base.vim
 unlet b:current_syntax
 
-syn include @js syntax/javascript.vim
-syn region jsBlock start="{" end="}" keepend contains=@js
+syn include @coffee syntax/coffee.vim
+syn region coffeeBlock start="{" end="}" keepend contains=@coffee

--- a/syntax/pegjs-base.vim
+++ b/syntax/pegjs-base.vim
@@ -1,0 +1,30 @@
+if exists("b:current_syntax")
+    finish
+endif
+
+syn include @js syntax/javascript.vim
+
+syn match pegOperator "[/.+*?&!]"
+syn region charSet start="\[" end="\]"
+syn match rule "[a-zA-Z$_][a-zA-Z$_0-9]*"
+syn match ruleDef "[_a-zA-Z$][a-zA-Z$_0-9]*" contained
+syn match equals "=" contained
+syn match initialize "[a-zA-Z$_][a-zA-Z$_0-9]*[\n\t ]*\".*\"[\n\t ]*=" contains=ruleDef,equals,innerLiteral
+syn match initialize "[a-zA-Z$_][a-zA-Z$_0-9]*[\n\t ]*'.*'[\n\t ]*=" contains=ruleDef,equals,innerLiteral
+syn match initialize "[a-zA-Z$_][a-zA-Z$_0-9]*[\n\t ]*=" contains=ruleDef,equals
+syn match exprLabel "[a-zA-Z$_][a-zA-Z$_0-9]*:"he=e-1
+syn region literal start="'" end="'"
+syn region literal start="\"" end="\""
+syn region innerLiteral start="'" end="'" contained
+syn region innerLiteral start="\"" end="\"" contained
+syn region comment start="/[*]" end="[*]/"
+syn region comment start="//" end="\n"
+
+hi def link ruleDef         PreProc
+hi def link rule            Type
+hi def link exprLabel       Identifier
+hi def link literal         String
+hi def link pegOperator     Operator
+hi def link charSet         Operator
+hi def link whitespace      PreProc
+hi def link innerLiteral    Comment


### PR DESCRIPTION
Refactored a bit, and added a sensible way to allow for coffeescript support to be available with the file suffix `.pegcs` while keeping `.pegjs` in a non-breaking way.