### PR TITLE
Don't keepend for js region

### DIFF
--- a/syntax/pegjs.vim
+++ b/syntax/pegjs.vim
@@ -26,7 +26,7 @@ syn region innerLiteral start="\"" end="\"" contained
 syn region comment start="/[*]" end="[*]/"
 syn region comment start="//" end="\n"
 
-syn region jsBlock start=/{/ms=s+1 end=/}/me=e-1 keepend contains=@js
+syn region jsBlock start=/{/ms=s+1 end=/}/me=e-1 contains=@js
 
 hi def link ruleDef         PreProc
 hi def link rule            Type


### PR DESCRIPTION
This will fix the visual bug where the closing brace inside a nested block inside a rule handler causes javascript to stop being highlighted.